### PR TITLE
Added a return error code, with appropriate error handling for authentication errors

### DIFF
--- a/src/main/kotlin/dev/murad/acorn/AcornController.kt
+++ b/src/main/kotlin/dev/murad/acorn/AcornController.kt
@@ -4,6 +4,8 @@ import auth.Acorn
 import entity.enrol.EnrolledCourse
 import exception.LoginFailedException
 import org.springframework.web.bind.annotation.*
+import java.lang.NullPointerException
+import java.lang.RuntimeException
 
 @RestController
 class AcornController {
@@ -11,11 +13,13 @@ class AcornController {
     @PostMapping("/auth")
     fun auth(account: Account): MutableList<EnrolledCourse>? {
         val acorn = Acorn(account.utorid, account.password)
+
         try {
             acorn.doLogin()
-        } catch (e: LoginFailedException) {
-            error(e.localizedMessage)
+        } catch (e: RuntimeException) {
+            throw AuthException("Authentication Error")
         }
+
         return (acorn.courseManager.appliedCourses)
     }
 

--- a/src/main/kotlin/dev/murad/acorn/AuthException.kt
+++ b/src/main/kotlin/dev/murad/acorn/AuthException.kt
@@ -1,0 +1,8 @@
+package dev.murad.acorn
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+import java.lang.RuntimeException
+
+@ResponseStatus(code = HttpStatus.FORBIDDEN)
+class AuthException(message: String) : RuntimeException(message)


### PR DESCRIPTION
Whenever an authentication error occurs, return HTTP Status FORBIDDEN.